### PR TITLE
update to how plugin is included after latest changes in derby

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,15 +7,14 @@ Supports derby-specific tags that ends with `:` and makes `if, else, else if, un
 
 ## Usage
 
-In your server-side code BEFORE requiring the app do
-```js
-// /src/server/index.js
+Right after creating your Derby app, add:
 
+```js
 // Add Jade compilation support
-derby.use( require('derby-jade') );
-// AFTER that require your derby app
-var app = require('../app');
+app.serverUse(module, 'derby-jade');
 ```
+
+Make sure this is before any calls to `app.loadViews()`.
 
 ## Derby.js-specific syntax
 

--- a/derby_adapter.js
+++ b/derby_adapter.js
@@ -10,8 +10,7 @@ var jadeCompiler = function(file, filename, options) {
   return out;
 };
 
-module.exports = function(derby) {
-  var App = Object.getPrototypeOf(derby).App;
-  App.prototype.viewExtensions.push('.jade');
-  App.prototype.compilers['.jade'] = jadeCompiler;
+module.exports = function(app) {
+  app.viewExtensions.push('.jade');
+  app.compilers['.jade'] = jadeCompiler;
 };


### PR DESCRIPTION
I just made and published some changes to Racer and Derby that make including server only plugins easier. I also changed it so that compiler plugins are best added to the app instead of Derby. Plugins should generally be done at the app level for greatest flexibility.
